### PR TITLE
Update InstallCommand.php For Laravel 5

### DIFF
--- a/src/Baum/Console/InstallCommand.php
+++ b/src/Baum/Console/InstallCommand.php
@@ -65,7 +65,6 @@ class InstallCommand extends Command {
 
     $this->writeModel($name);
 
-    $this->call('dump-autoload');
   }
 
   /**
@@ -109,7 +108,7 @@ class InstallCommand extends Command {
    * @return string
    */
   protected function getMigrationsPath() {
-    return $this->laravel['path'].'/database/migrations';
+    return $this->laravel['path.base'].'/database/migrations';
   }
 
   /**
@@ -118,7 +117,7 @@ class InstallCommand extends Command {
    * @return string
    */
   protected function getModelsPath() {
-    return $this->laravel['path'].'/models';
+    return $this->laravel['path'];
   }
 
 }


### PR DESCRIPTION
Due to laravel 5 new folder structure some changes made for console commands. Also it is not requried to dump-autoload due to new namespacing.
